### PR TITLE
WIP: OS dependent linking flags fix in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ bin/
 
 # Mac files
 .DS_Store
+
+#VS Code
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++1z
-LDFLAGS=-framework OpenGL -lglfw -lglew -std=c++14
+CFLAGS=-c -Wall -std=c++14
+LDFLAGS=-lglfw -std=c++14
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	LDFLAGS += -framework OpenGL -lglew
+endif
+ifeq ($(UNAME_S),Linux)
+	LDFLAGS += -lGL -lGLEW -lGLU
+endif
 
 SOURCES=$(wildcard ./src/*.cpp) $(wildcard ./src/**/*.cpp)
 OBJECTS=$(SOURCES:.cpp=.o)

--- a/src/Core/Engine.cpp
+++ b/src/Core/Engine.cpp
@@ -1,6 +1,6 @@
 #include "Engine.hpp"
 
-unique_ptr<Engine> pointerInstance = nullptr;
+unique_ptr<Engine> Engine::pointerInstance = nullptr;
 
 unique_ptr<Engine> &Engine::instance() { return pointerInstance; }
 

--- a/src/Core/Engine.hpp
+++ b/src/Core/Engine.hpp
@@ -33,7 +33,7 @@ public:
   GLFWwindow *window;
 
 private:
-  static inline unique_ptr<Engine> pointerInstance;
+  static unique_ptr<Engine> pointerInstance;
 
   void initOpenGL();
 


### PR DESCRIPTION
What this does
 - [x] fix the LDFLAGS declaration in the Makefile that uses `-framework` flag that is dependent to clang in Apple hardware
 - [x] change the `inline static` variable in Engine to just `static` variable. Because in Linux mint, it keeps giving the error `src/Core/Engine.hpp:36:36: error: ‘pointerInstance’ declared as an ‘inline’ field` which really does not say much.
 - [x] some .gitignore changes for vscode and stuff

what hasn't been done
 - [ ] test the Makefile in Apple hardware again
 - [ ] check against Windows OS

yo @rayandrews 
